### PR TITLE
Add 'main' and 'module' in packages.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "scrambling-letters",
   "version": "1.6.1",
   "main": "dist/scrambler.cjs.js",
-  "module": "dist/scrambler.ems.js",
+  "module": "dist/scrambler.esm.js",
   "description": "A lightweight javascript library for scrambling letters within a piece of text, giving a nice decoding effect.",
   "keywords": [
     "scramble",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,8 @@
 {
   "name": "scrambling-letters",
   "version": "1.6.1",
+  "main": "dist/scrambler.cjs.js",
+  "module": "dist/scrambler.ems.js",
   "description": "A lightweight javascript library for scrambling letters within a piece of text, giving a nice decoding effect.",
   "keywords": [
     "scramble",


### PR DESCRIPTION
This change will allow you to call in the package as one would expect using an npm package.

`import Scrambler from 'scrambling-letters'`

or

`const Scrambler = require('scrambling-letters')`